### PR TITLE
feat: add Laravel 10 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 php: [8.5, 8.4, 8.3, 8.2]
-                laravel: [13.*, 12.*, 11.*]
+                laravel: [13.*, 12.*, 11.*, 10.*]
                 stability: [prefer-lowest, prefer-stable]
                 include:
                   - laravel: 13.*
@@ -23,6 +23,8 @@ jobs:
                     testbench: 10.*
                   - laravel: 11.*
                     testbench: ^9.9
+                  - laravel: 10.*
+                    testbench: ^8.0
                 exclude:
                   - laravel: 13.*
                     php: 8.2

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "sentry/sentry": "^4.10"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",
-        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^10.1|^11.0",
         "sentry/sentry-laravel": "^4.13"
     },


### PR DESCRIPTION
## Changes

- Expand `illuminate/support` constraint to include `^10.0`
- Expand `orchestra/testbench` dev constraint to include `^8.0`

PHP requirement stays at `^8.2`.